### PR TITLE
GDB-12637: Update default MCP server URL and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Install the gateway globally using npm:
 npm install -g graphdb-mcphub-gateway
 ```
 
+By default, the original gateway connects to the public MCP Hub at https://server.mcphub.ai/api/mcp, which provides access to various pre-configured MCP services.
+
+In this fork, the default endpoint has been changed to http://localhost:7200/mcp, which corresponds to the default GraphDB MCP server URL (assuming GraphDB is running on its default port).
+
 ```bash
 export MCPHUB_SERVER_URL=https://your-secured-mcp-server.com/mcp
 ```
@@ -32,5 +36,5 @@ Authorization Header for Secured GraphDB MCP Server
 If the gateway will communicate with a secured GraphDB MCP server, set the following environment variable to pass an authorization token (e.g., Bearer token or API key) via the Authorization header:
 
 ```bash
-export MCPHUB_AUTHORIZATION_HEADER="Bearer YOUR_TOKEN_HERE"
+export MCPHUB_AUTHORIZATION_HEADER="YOUR_TOKEN_HERE"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphdb-mcphub-gateway",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "MCPHub Gateway for Claude Desktop, supporting Authorization header passthrough.",
     "type": "module",
     "bin": {

--- a/src/mcphub-gateway.ts
+++ b/src/mcphub-gateway.ts
@@ -3,7 +3,7 @@
 import EventSource from "eventsource";
 
 // Configuration
-const MCP_SERVER_URL = process.env.MCPHUB_SERVER_URL || "https://server.mcphub.ai/api/mcp";
+const MCP_SERVER_URL = process.env.MCPHUB_SERVER_URL ?? "http://localhost:7200/mcp";
 const MCP_SERVER_AUTHORIZATION_HEADER: string | null = process.env.MCPHUB_AUTHORIZATION_HEADER ?? null;
 
 const baseUrl = MCP_SERVER_URL;


### PR DESCRIPTION
- Changed the default MCP_SERVER_URL from https://server.mcphub.ai/api/mcp to http://localhost:7200/mcp, which is the default endpoint for GraphDB.

- Corrected an inaccurate statement in the README.md and added a note explaining the new default value.