### PR TITLE
GDBSB-667 - Add User-Agent header for WAF validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "graphdb-mcphub-gateway",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "graphdb-mcphub-gateway",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.3",
                 "eventsource": "^2.0.2"

--- a/src/mcphub-gateway.ts
+++ b/src/mcphub-gateway.ts
@@ -36,6 +36,7 @@ class MCPHubGateway {
         return new Promise((resolve, reject) => {
             const headers: Record<string, string> = {
                 'Accept': 'text/event-stream',
+                'User-Agent': 'graphdb-mcp-gateway'
             };
 
             if (MCP_SERVER_AUTHORIZATION_HEADER) {


### PR DESCRIPTION
Requests to cloud service providers pass some firewalls. For AWS, this is WAF. AWS is where the GraphDB sandbox is hosted. WAF requires an user-agent header. Set up an explicit header so it passes the firewall.